### PR TITLE
Make Retrofit use our custom Gson instance

### DIFF
--- a/src/org/lumeh/routemaster/net/NetworkModule.java
+++ b/src/org/lumeh/routemaster/net/NetworkModule.java
@@ -47,10 +47,11 @@ public class NetworkModule {
 
     @Provides
     @Singleton
-    RouteMasterApi provideRouteMasterApi(Client client) {
+    RouteMasterApi provideRouteMasterApi(Client client, Converter converter) {
         return new RestAdapter.Builder()
             .setEndpoint("http://routemaster.lumeh.org")
             .setClient(client)
+            .setConverter(converter)
             .build()
             .create(RouteMasterApi.class);
     }


### PR DESCRIPTION
This makes it use custom handlers for Location and Date objects, instead
of using Gson's default handlers.
